### PR TITLE
Heroes compatibility

### DIFF
--- a/src/main/java/com/gmail/molnardad/quester/qevents/ExperienceQevent.java
+++ b/src/main/java/com/gmail/molnardad/quester/qevents/ExperienceQevent.java
@@ -1,30 +1,35 @@
 package com.gmail.molnardad.quester.qevents;
 
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 
+import com.gmail.molnardad.quester.Quester;
 import com.gmail.molnardad.quester.utils.ExpManager;
+import com.herocraftonline.heroes.Heroes;
+import com.herocraftonline.heroes.characters.Hero;
+import com.herocraftonline.heroes.characters.classes.HeroClass.ExperienceType;
 
 public final class ExperienceQevent extends Qevent {
 
 	public static final String TYPE = "EXP";
 	private final int amount;
-	
+
 	public ExperienceQevent(int occ, int del, int amt) {
 		super(occ, del);
 		this.amount = amt;
 	}
-	
+
 	@Override
 	public String getType() {
 		return TYPE;
 	}
-	
+
 	@Override
 	public int getOccasion() {
 		return occasion;
 	}
-	
+
 	@Override
 	public String toString() {
 		return TYPE + ": " + amount + appendSuper();
@@ -35,21 +40,29 @@ public final class ExperienceQevent extends Qevent {
 		super.serialize(section, TYPE);
 		section.set("amount", amount);
 	}
-	
+
 	public static ExperienceQevent deser(int occ, int del, ConfigurationSection section) {
 		int amt;
-		
+
 		if(section.isInt("amount"))
 			amt = section.getInt("amount");
 		else
 			return null;
-		
+
 		return new ExperienceQevent(occ, del, amt);
 	}
 
 	@Override
 	void run(Player player) {
-		ExpManager expMan = new ExpManager(player);
-		expMan.changeExp(amount);
+                if (Quester.heroes){
+                    Hero hero = ((Heroes) Bukkit.getServer().getPluginManager().getPlugin("Heroes")).getCharacterManager().getHero(player);
+                    if (hero.hasExperienceType(ExperienceType.QUESTING)){
+                        hero.addExp(amount, hero.getHeroClass(), hero.getPlayer().getLocation());
+                        hero.syncExperience();
+                    }
+                    return;
+        	}
+                ExpManager expMan = new ExpManager(player);
+                expMan.changeExp(amount);
 	}
 }


### PR DESCRIPTION
Allows players on HeroClasses with QUESTING experience types to properly recieve experience via the EXP-type event. Ofc a 'heroes' boolean has to be created on Quester.java but that's the easy part ;)
